### PR TITLE
Added device_tracker auto discovery

### DIFF
--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -110,6 +110,10 @@ class MQTT {
         return `${this.prefix}/${this.instance}/refresh_interval_current_val`;
     }
 
+    getDeviceTrackerConfigTopic() {
+        return `${this.prefix}/device_tracker/${this.instance}/config`;
+    }
+
     /**
      *
      * @param {DiagnosticElement} diag


### PR DESCRIPTION
- Added device_tracker auto discovery
  - The device_tracker auto discovery config is published to: "homeassistant/device_tracker/(VIN)/config" and the GPS coordinates are still read from the original topic automatically at: "homeassistant/device_tracker/(VIN)/getlocation/state"
  - Also added GPS based speed and direction to the device_tracker attributes

- Added new retained topic of "homeassistant/(VIN)/refresh_interval_current_val" to monitor current refresh value set via MQTT