### PR TITLE
fix: invalid state_class on device_class types of `energy`

### DIFF
--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -297,9 +297,11 @@ class MQTT {
         // TODO: this sucks, find a better way to map these diagnostics and their elements for discovery.
         switch (diagEl.name) {
             case 'LIFETIME ENERGY USED':
+                return this.mapSensorConfigPayload(diag, diagEl, 'total', 'energy');
             case 'LIFETIME EFFICIENCY':
+                return this.mapSensorConfigPayload(diag, diagEl, 'total', 'energy');
             case 'ELECTRIC ECONOMY':
-                return this.mapSensorConfigPayload(diag, diagEl, 'measurement', 'energy');
+                return this.mapSensorConfigPayload(diag, diagEl, 'total', 'energy');
             case 'INTERM VOLT BATT VOLT':
             case 'EV PLUG VOLTAGE':
                 return this.mapSensorConfigPayload(diag, diagEl, 'measurement', 'voltage');
@@ -364,6 +366,7 @@ class MQTT {
             case 'LAST TRIP ELECTRIC ECON':
             case 'LIFETIME MPGE':
             case 'CHARGER POWER LEVEL':
+                return this.mapSensorConfigPayload(diag, diagEl, undefined, undefined);
             default:
                 return this.mapSensorConfigPayload(diag, diagEl, 'measurement');
         }


### PR DESCRIPTION
The energy device class cannot have a state class of measurement.

```
ValueError: Sensor sensor.charger_power_level has device class 'None', state class 'measurement' unit 'None' and suggested precision 'None' thus indicating it has a numeric value; however, it has the non-numeric value: 'REDUCTION_CHARGE_LEVEL_1' (<class 'str'>)
```

Charger power level must be undefined as state class measurement requires numeric values.