### PR TITLE
Added option to group all sensors in one MQTT device if desired

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -576,7 +576,7 @@ logger.info('!-- Starting OnStar2MQTT Polling --!');
                     let tasks;
                     if (mqttConfig.listAllSensorsTogether === true) {
                         tasks = [
-                            mqttHA.createButtonConfigPayload(v),                            
+                            mqttHA.createButtonConfigPayload(v),
                         ];
                     } else {
                         tasks = [
@@ -598,9 +598,23 @@ logger.info('!-- Starting OnStar2MQTT Polling --!');
                             client.publish(buttonConfig, JSON.stringify(configPayload), { retain: true });
                         });
                     });
-
-                    buttonConfigsPublished = 'true';
                     logger.info(`Button Configs Published!`);
+
+                    const sensors = [
+                        { name: 'oil_life', component: null, icon: 'mdi:oil-level' },
+                        { name: 'tire_pressure', component: 'tire_pressure_lf_message', icon: 'mdi:car-tire-alert' },
+                        { name: 'tire_pressure', component: 'tire_pressure_lr_message', icon: 'mdi:car-tire-alert' },
+                        { name: 'tire_pressure', component: 'tire_pressure_rf_message', icon: 'mdi:car-tire-alert' },
+                        { name: 'tire_pressure', component: 'tire_pressure_rr_message', icon: 'mdi:car-tire-alert' },
+                    ];
+
+                    for (let sensor of sensors) {
+                        const sensorMessagePayload = mqttHA.createSensorMessageConfigPayload(sensor.name, sensor.component, sensor.icon);
+                        logger.debug('Sensor Message Payload:', sensorMessagePayload);
+                        client.publish(sensorMessagePayload.topic, JSON.stringify(sensorMessagePayload.payload), { retain: true });
+                    }                    
+                    logger.info(`Sensor Message Configs Published!`);
+                    buttonConfigsPublished = 'true';
                 }
             }
 

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -512,6 +512,51 @@ class MQTT {
         return { topic, payload };
     }
 
+    createSensorMessageConfigPayload(sensor, component, icon) {
+        //let topic = `${this.prefix}/sensor/${this.instance}/${sensor}_message/config`;
+
+        let topic, unique_id, sensor_name, value_template;
+        if (!component) {
+            topic = `${this.prefix}/sensor/${this.instance}/${sensor}_message/config`;
+            unique_id = MQTT.convertName(this.vehicle.vin) + '_' + sensor;
+            sensor_name = `${sensor.split('_').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')} Message`;
+            value_template = `{{ value_json.${sensor}_message }}`;
+        } else {
+            topic = `${this.prefix}/sensor/${this.instance}/${sensor}_${component}_message/config`;
+            unique_id = MQTT.convertName(this.vehicle.vin) + '_' + sensor + '_' + component;
+            let component_words = component.split('_');
+            component_words = component_words.map(component_word => {
+                if (component_word === 'lf' || component_word === 'rf' || component_word === 'lr' || component_word === 'rr') {
+                    return component_word.toUpperCase();
+                } else {
+                    return component_word.charAt(0).toUpperCase() + component_word.slice(1);
+                }
+            });
+            sensor_name = component_words.join(' ');
+            value_template = `{{ value_json.${component} }}`;
+        }
+
+        let payload = {
+            "device": {
+                "identifiers": [this.vehicle.vin],
+                "manufacturer": this.vehicle.make,
+                "model": this.vehicle.year + ' ' + this.vehicle.model,
+                "name": this.vehicle.toString(),
+                "suggested_area": this.vehicle.toString(),
+            },
+            "availability": {
+                "topic": this.getAvailabilityTopic(),
+                "payload_available": 'true',
+                "payload_not_available": 'false',
+            },
+            "unique_id": unique_id,
+            "name": sensor_name,
+            "state_topic": `${this.prefix}/sensor/${this.instance}/${sensor}/state`,
+            "value_template": value_template,
+            "icon": icon,
+        };
+        return { topic, payload };
+    }
 
     /**
      *

--- a/test/mqtt.spec.js
+++ b/test/mqtt.spec.js
@@ -1333,5 +1333,109 @@ describe('MQTT', () => {
             });
         });
 
+        describe('createSensorMessageConfigPayload', () => {
+            beforeEach(() => {
+                // Set up the MQTT instance and vehicle details
+                mqtt.vehicle = {
+                    vin: '1234',
+                    make: 'TestMake',
+                    model: 'TestModel',
+                    year: '2022',
+                    toString: () => 'TestVehicle'
+                };
+                mqtt.prefix = 'testPrefix';
+                mqtt.instance = 'testInstance';
+            });
+
+            it('should create sensor message config payload when component is not provided', () => {
+                const sensor = 'testSensor';
+                const icon = 'testIcon';
+                const expected = {
+                    topic: 'testPrefix/sensor/testInstance/testSensor_message/config',
+                    payload: {
+                        device: {
+                            identifiers: ['1234'],
+                            manufacturer: 'TestMake',
+                            model: '2022 TestModel',
+                            name: 'TestVehicle',
+                            suggested_area: 'TestVehicle',
+                        },
+                        availability: {
+                            topic: mqtt.getAvailabilityTopic(),
+                            payload_available: 'true',
+                            payload_not_available: 'false',
+                        },
+                        unique_id: '1234_testSensor',
+                        name: 'TestSensor Message',
+                        state_topic: 'testPrefix/sensor/testInstance/testSensor/state',
+                        value_template: '{{ value_json.testSensor_message }}',
+                        icon: 'testIcon',
+                    }
+                };
+                const result = mqtt.createSensorMessageConfigPayload(sensor, undefined, icon);
+                assert.deepStrictEqual(result, expected);
+            });
+
+            it('should create sensor message config payload when component is provided', () => {
+                const sensor = 'testSensor';
+                const component = 'testComponent';
+                const icon = 'testIcon';
+                const expected = {
+                    topic: 'testPrefix/sensor/testInstance/testSensor_testComponent_message/config',
+                    payload: {
+                        device: {
+                            identifiers: ['1234'],
+                            manufacturer: 'TestMake',
+                            model: '2022 TestModel',
+                            name: 'TestVehicle',
+                            suggested_area: 'TestVehicle',
+                        },
+                        availability: {
+                            topic: mqtt.getAvailabilityTopic(),
+                            payload_available: 'true',
+                            payload_not_available: 'false',
+                        },
+                        unique_id: '1234_testSensor_testComponent',
+                        name: 'TestComponent',
+                        state_topic: 'testPrefix/sensor/testInstance/testSensor/state',
+                        value_template: '{{ value_json.testComponent }}',
+                        icon: 'testIcon',
+                    }
+                };
+                const result = mqtt.createSensorMessageConfigPayload(sensor, component, icon);
+                assert.deepStrictEqual(result, expected);
+            });
+
+        it('should create sensor message config payload when component is provided', () => {
+            const sensor = 'oil_life';
+            const component = undefined;
+            const icon = 'testIcon';
+            const expected = {
+                topic: 'testPrefix/sensor/testInstance/oil_life_message/config',
+                payload: {
+                    device: {
+                        identifiers: ['1234'],
+                        manufacturer: 'TestMake',
+                        model: '2022 TestModel',
+                        name: 'TestVehicle',
+                        suggested_area: 'TestVehicle',
+                    },
+                    availability: {
+                        topic: mqtt.getAvailabilityTopic(),
+                        payload_available: 'true',
+                        payload_not_available: 'false',
+                    },
+                    unique_id: '1234_oil_life',
+                    name: 'Oil Life Message',
+                    state_topic: 'testPrefix/sensor/testInstance/oil_life/state',
+                    value_template: '{{ value_json.oil_life_message }}',
+                    icon: 'testIcon',
+                }
+            };
+            const result = mqtt.createSensorMessageConfigPayload(sensor, component, icon);
+            assert.deepStrictEqual(result, expected);
+        });
+    });
+
     });
 });


### PR DESCRIPTION
- Added an option to group all numeric/component sensors and command status sensors in the same MQTT device if desired. The default which carries over from the previous version is to group them separately.
- Added Oil Life and Tire Pressure status messages to MQTT auto-discovery topics.
- Added additional tests