### PR TITLE
Map Additional EV Sensors and Address Numeric Sensors with Units "XXX"

### DIFF
--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -767,8 +767,8 @@ class MQTT {
 
     mapSensorConfigPayload(diag, diagEl, state_class, device_class, name, attr) {
         name = name || MQTT.convertFriendlyName(diagEl.name);
-        // Ignore units that are "NA"
-        const unit = diagEl.unit && diagEl.unit.toUpperCase() === 'NA' ? undefined : diagEl.unit;
+        // Ignore units that are "NA" or "XXX"
+        const unit = diagEl.unit && !['NA', 'XXX'].includes(diagEl.unit.toUpperCase()) ? diagEl.unit : undefined;
         return _.extend(
             this.mapBaseConfigPayload(diag, diagEl, state_class, device_class, name, attr),
             { unit_of_measurement: unit });

--- a/test/mqtt.spec.js
+++ b/test/mqtt.spec.js
@@ -1928,6 +1928,18 @@ describe('MQTT', () => {
             assert.strictEqual(result.unit_of_measurement, 'kPa');
             assert.strictEqual(result.state_class, 'measurement');
         });
+
+        it('should handle XXX unit values by converting them to undefined', () => {
+            const d = new Diagnostic({});
+            const diagEl = {
+                name: 'TEST_SENSOR',
+                value: '123',
+                unit: 'XXX'
+            };
+            const result = mqtt.mapSensorConfigPayload(d, diagEl, 'measurement');
+            assert.strictEqual(result.unit_of_measurement, undefined);
+            assert.strictEqual(result.state_class, 'measurement');
+        });
     });
 
     describe('constructor initialization', () => {


### PR DESCRIPTION
This pull request introduces enhancements to the `MQTT` class in `src/mqtt.js` and updates the corresponding tests in `test/mqtt.spec.js`. The changes focus on improving the handling of sensor configuration payloads and adding new cases for projected EV range.

Enhancements to sensor configuration:

* Updated `mapSensorConfigPayload` method to ignore units that are either "NA" or "XXX" (`src/mqtt.js`).

New cases for projected EV range:

* Added new cases for `PROJECTED EV RANGE GENERAL AWAY TARGET CHARGE SET` and its variant with "MI" unit in the `mapSensorConfigPayload` method (`src/mqtt.js`).
* Added corresponding tests for the new cases to ensure correct mapping of sensor configuration payloads (`test/mqtt.spec.js`).

Additional test improvements:

* Added a test to verify that the "XXX" unit value is correctly converted to `undefined` (`test/mqtt.spec.js`).