### PR TITLE
Switch to Debian-based image for new authentication compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:22-alpine
+#FROM node:22-alpine
+#FROM node:22-bullseye-slim
+FROM node:22-bookworm-slim
 
 RUN mkdir /app
 WORKDIR /app
@@ -9,6 +11,7 @@ RUN npm -v
 RUN npm update -g --no-fund
 RUN npm -v
 RUN npm ci --omit=dev --no-fund --legacy-peer-deps
+RUN npx patchright install chromium --with-deps
 
 COPY ["src", "/app/src"]
 


### PR DESCRIPTION
Change the base image to a Debian-based variant to ensure compatibility with the new authentication mechanism.