### PR TITLE
Fix: Improve Sensor Handling

### DIFF
--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -971,10 +971,12 @@ class MQTT {
             let value;
             switch (e.name) {
                 case 'EV PLUG STATE': // unplugged/plugged
-                    value = e.value && e.value.toLowerCase() === 'plugged';
+                    // Return null if value is null/undefined to show as unavailable in HA
+                    value = (e.value === null || e.value === undefined) ? null : (e.value.toLowerCase() === 'plugged');
                     break;
                 case 'EV CHARGE STATE': // not_charging/charging
-                    value = e.value && e.value.toLowerCase() === 'charging';
+                    // Return null if value is null/undefined to show as unavailable in HA
+                    value = (e.value === null || e.value === undefined) ? null : (e.value.toLowerCase() === 'charging');
                     break;
                 case 'PRIORITY CHARGE INDICATOR': // FALSE/TRUE
                     value = e.value === 'TRUE';
@@ -1019,10 +1021,14 @@ class MQTT {
                     value = e.value === 'TRUE';
                     break;
                 default:
-                    // coerce to number if possible, API uses strings :eyeroll:
-                    // eslint-disable-next-line no-case-declarations
-                    const num = _.toNumber(e.value);
-                    value = _.isNaN(num) ? e.value : num;
+                    // Return null for null/undefined values to show as unavailable in HA
+                    if (e.value === null || e.value === undefined) {
+                        value = null;
+                    } else {
+                        // coerce to number if possible, API uses strings :eyeroll:
+                        const num = _.toNumber(e.value);
+                        value = _.isNaN(num) ? e.value : num;
+                    }
                     break;
             }
             state[MQTT.convertName(e.name)] = value;


### PR DESCRIPTION
This pull request improves the handling of sensor values in the `MQTT` class to better support Home Assistant (HA) integration, particularly in cases where sensor values may be `null` or `undefined`. The changes ensure that unavailable sensor values are correctly represented and also refine the configuration of specific sensor payloads.

**Improvements to sensor value handling:**

* For the `EV PLUG STATE` and `EV CHARGE STATE` cases, the code now explicitly returns `null` when the value is `null` or `undefined`, ensuring that unavailable states are correctly shown as unavailable in Home Assistant.
* In the `default` case, the code now checks for `null` or `undefined` values and returns `null` accordingly, rather than attempting to coerce them to a number or string. This prevents invalid data from being sent when a sensor is unavailable.

**Sensor configuration improvements:**

* The payload configuration for the `ENGINE_AIR_FILTER_LIFE_RMAINING_HMI` sensor now explicitly sets the device class to `'measurement'`, which improves the accuracy of sensor representation in Home Assistant.