### PR TITLE
Fix: Include Expired and Inactive Recalls in Unrepaired Active Count

### DIFF
--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -1039,10 +1039,11 @@ class MQTT {
         const recallInfo = _.get(recallData, 'data.vehicleDetails.recallInfo', []);
         const activeRecalls = recallInfo.filter(r => r.recallStatus === 'A');
         const incompleteRepairs = recallInfo.filter(r => r.repairStatus === 'incomplete');
-        // Filter for recalls that are (Active OR Expired) AND unrepaired
-        // Include expired recalls because the safety issue still exists even if the recall program expired
+        // Filter for recalls that are (Active, Expired, or Inactive) AND unrepaired
+        // Include expired/inactive recalls because users should be aware of known safety issues
+        // even if they can't currently get them fixed
         const unrepairedActiveRecalls = recallInfo.filter(r => 
-            (r.recallStatus === 'A' || r.recallStatus === 'E') && r.repairStatus === 'incomplete'
+            (r.recallStatus === 'A' || r.recallStatus === 'E' || r.recallStatus === 'I') && r.repairStatus === 'incomplete'
         );
         
         const state = {


### PR DESCRIPTION
This pull request updates the logic for tracking vehicle recalls to ensure that users are made aware of all unrepaired recalls, including those that are expired or inactive, not just active recalls. The associated tests are expanded to verify this broader coverage.

**Recall status logic improvements:**

* The `unrepairedActiveRecalls` filter in `src/mqtt.js` now includes recalls with statuses 'Active', 'Expired', or 'Inactive' that are unrepaired, so users are notified about all known safety issues, regardless of current fix availability.

**Test coverage enhancements:**

* Existing tests in `test/recall-sensor.spec.js` are updated to match the new logic, confirming that unrepaired recalls with 'Inactive' status are counted.
* Added new test cases to verify that unrepaired recalls with 'Expired' status are included in the count and that the recall count reflects all relevant recalls.
* Added a test to ensure that unrepaired recalls with 'Inactive' status are included for user awareness, even if they cannot currently be fixed.