### PR TITLE
Add support for refreshEVChargingMetrics from OnStarJS2 2.14.0

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -185,6 +185,10 @@ class Commands {
         return this.onstar.getEVChargingMetrics();
     }
 
+    async refreshEVChargingMetrics() {
+        return this.onstar.refreshEVChargingMetrics();
+    }
+
     async getVehicleRecallInfo() {
         return this.onstar.getVehicleRecallInfo();
     }

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -144,6 +144,10 @@ class MQTT {
                 Name: 'getEVChargingMetrics',
                 Icon: 'mdi:ev-station',
             },
+            RefreshEVChargingMetrics: {
+                Name: 'refreshEVChargingMetrics',
+                Icon: 'mdi:refresh',
+            },
             GetVehicleRecallInfo: {
                 Name: 'getVehicleRecallInfo',
                 Icon: 'mdi:alert-octagon',

--- a/test/commands.spec.js
+++ b/test/commands.spec.js
@@ -30,6 +30,7 @@ describe('Commands', () => {
             getVehicleDetails: () => Promise.resolve(),
             getOnstarPlan: () => Promise.resolve(),
             getEVChargingMetrics: () => Promise.resolve(),
+            refreshEVChargingMetrics: () => Promise.resolve(),
             getVehicleRecallInfo: () => Promise.resolve(),
         };
 
@@ -167,6 +168,11 @@ describe('Commands', () => {
 
     it('should call getEVChargingMetrics method', async () => {
         const result = await commands.getEVChargingMetrics();
+        assert.strictEqual(result, undefined);
+    });
+
+    it('should call refreshEVChargingMetrics method', async () => {
+        const result = await commands.refreshEVChargingMetrics();
         assert.strictEqual(result, undefined);
     });
 


### PR DESCRIPTION
- Added refreshEVChargingMetrics() method to Commands class
- Added RefreshEVChargingMetrics button to MQTT auto-discovery
- Added test coverage for the new method
- All 356 tests passing