### PR TITLE
Add unit caching for v3 API stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ temp-*
 onstar2mqtt.env
 *tokens.json
 .secrets
+
+# Unit cache files (per-VIN)
+.unit_cache_*.json

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ There is no affiliation with this project and GM, Chevrolet nor OnStar. In fact,
 
 - **OnStar API v3 Support** - Updated to OnStarJS 2.10.0 with full API v3 compatibility
 - **Enhanced Reliability** - Improved handling of OnStar API field naming variations
+- **Unit Stability Fix** - Automatic caching of sensor units to handle API instability where units intermittently return as null, preventing Home Assistant unit conversion errors
 
 **What This Means for You:**
 
@@ -246,10 +247,16 @@ docker run \
   --env MQTT_PASSWORD \
   --env MQTT_ONSTAR_POLLING_STATUS_TOPIC \
   -v ~/onstar2mqtt-tokens:/app/tokens \
+  -v ~/onstar2mqtt-data:/app/data \
+  --env UNIT_CACHE_DIR=/app/data \
   bigthundersr/onstar2mqtt:latest
 ```
 
-**NOTE:** TOKEN_LOCATION is optional, but STRONGLY RECOMMENDED and allows you to save/read tokens from persistent storage
+**NOTE:**
+
+- TOKEN_LOCATION is optional, but STRONGLY RECOMMENDED and allows you to save/read tokens from persistent storage
+- UNIT_CACHE_DIR volume mount is optional but recommended for persistent unit caching across container restarts (prevents unit conversion errors during API instability)
+- If UNIT_CACHE_DIR is not set, cache files will use TOKEN_LOCATION automatically
 
 [GitHub Container Registry](https://github.com/BigThunderSR/onstar2mqtt/pkgs/container/onstar2mqtt)
 
@@ -267,6 +274,8 @@ docker run \
   --env MQTT_PASSWORD \
   --env MQTT_ONSTAR_POLLING_STATUS_TOPIC \
   -v ~/onstar2mqtt-tokens:/app/tokens \
+  -v ~/onstar2mqtt-data:/app/data \
+  --env UNIT_CACHE_DIR=/app/data \
   ghcr.io/bigthundersr/onstar2mqtt:latest
 ```
 
@@ -285,8 +294,10 @@ onstar2mqtt:
     - ONSTAR_DEVICEID=
     - ONSTAR_VIN=
     - MQTT_HOST=
+    - UNIT_CACHE_DIR=/app/data
   volumes:
     - ~/onstar2mqtt-tokens:/app/tokens
+    - ~/onstar2mqtt-data:/app/data
 ```
 
 [GitHub Container Registry](https://github.com/BigThunderSR/onstar2mqtt/pkgs/container/onstar2mqtt)
@@ -302,8 +313,10 @@ onstar2mqtt:
     - ONSTAR_DEVICEID=
     - ONSTAR_VIN=
     - MQTT_HOST=
+    - UNIT_CACHE_DIR=/app/data
   volumes:
     - ~/onstar2mqtt-tokens:/app/tokens
+    - ~/onstar2mqtt-data:/app/data
 ```
 
 onstar2mqtt.env:
@@ -314,6 +327,7 @@ ONSTAR_PASSWORD=
 ONSTAR_TOTP=
 ONSTAR_PIN=
 TOKEN_LOCATION=/app/tokens  # (NOTE: This is optional and allows you to save/read tokens from persistent storage)
+UNIT_CACHE_DIR=/app/data  # (NOTE: This is optional but recommended for persistent unit caching across container restarts)
 MQTT_USERNAME=
 MQTT_PASSWORD=
 MQTT_ONSTAR_POLLING_STATUS_TOPIC=

--- a/docs/UNIT_CACHE_FIX.md
+++ b/docs/UNIT_CACHE_FIX.md
@@ -1,0 +1,336 @@
+# v3 API Unit Stability Fix
+
+## Overview
+
+This document describes the unit caching solution implemented to handle intermittent OnStar v3 API instability where diagnostic element units sometimes return as null or missing.
+
+**TL;DR**: The application now automatically caches and persists sensor units to disk, maintaining stability across API failures and application restarts. No user action required.
+
+## Problem
+
+The OnStar v3 API has an intermittent issue where some diagnostic elements return `null` or missing units (`uom` field) between data refreshes. This causes Home Assistant errors like:
+
+```text
+The unit of 'Vehicle Lifetime Fuel Economy' (sensor.vehicle_lifetime_fuel_econ)
+changed to '' which can't be converted to the previously stored unit, 'km/L'.
+```
+
+When a sensor's unit changes from a valid value (e.g., 'km/L') to empty/null, Home Assistant cannot reconcile this with its historical data, resulting in errors and potential loss of statistics.
+
+## Root Cause
+
+The v3 API response for diagnostic elements sometimes includes:
+
+- `"uom": "KM/L"` (valid unit)
+- `"uom": null` (null unit)
+- `"uom": "N/A"` (placeholder)
+- Missing `uom` field entirely
+
+This instability occurs unpredictably, even for the same vehicle and sensor between consecutive API calls. The inconsistency appears to be a backend issue with the OnStar v3 API.
+
+## Solution
+
+Implemented a **unit caching mechanism** in `src/diagnostic.js` that:
+
+1. **Caches valid units**: When a diagnostic element has a valid unit (not null, undefined, or 'N/A'), the unit is cached using the element name as the key.
+
+2. **Uses cached units as fallback**: When the API returns a null/undefined/missing unit, the code checks the cache and uses the last known valid unit.
+
+3. **Allows legitimate updates**: If the API returns a different valid unit (e.g., unit format changes), the cache is updated with the new value.
+
+4. **Excludes invalid values**: Units like 'N/A' are never cached since they're placeholders, not real units.
+
+### Code Changes
+
+**File: `src/diagnostic.js`**
+
+```javascript
+// Added at module level
+const unitCache = new Map();
+
+// Modified DiagnosticElement constructor
+constructor(ele) {
+    this._name = ele.name;
+    this._message = ele.message;
+    let unitValue = ele.uom || ele.unit;
+
+    // WORKAROUND: v3 API sometimes returns null units intermittently
+    const cacheKey = ele.name;
+    if (!unitValue || unitValue === 'null' || unitValue === 'N/A') {
+        const cachedUnit = unitCache.get(cacheKey);
+        if (cachedUnit) {
+            logger.info(`Using cached unit for ${ele.name}: ${cachedUnit}`);
+            unitValue = cachedUnit;
+        }
+    } else {
+        // Cache valid units for future use
+        if (unitValue !== 'N/A') {
+            unitCache.set(cacheKey, unitValue);
+            logger.debug(`Cached unit for ${ele.name}: ${unitValue}`);
+        }
+    }
+
+    this.measurement = new Measurement(ele.value, unitValue);
+    // ... rest of constructor
+}
+```
+
+### Cache Persistence
+
+The unit cache is **persisted to disk** in `.unit_cache_<VIN>.json` to survive application restarts:
+
+- **Automatic saving**: Cache is saved immediately after any change
+- **Automatic loading**: Cache is loaded from disk when the application starts
+- **Location**: `.unit_cache_<VIN>.json` in configurable directory (VIN from ONSTAR_VIN environment variable)
+- **Directory priority**: UNIT_CACHE_DIR → TOKEN_LOCATION → process.cwd()
+- **HA Add-on**: Automatically uses TOKEN_LOCATION, keeping cache with tokens
+- **Format**: JSON file mapping sensor names to units
+- **Multi-vehicle support**: Each VIN gets its own cache file to avoid collisions
+
+This ensures that even if the application restarts during a period when the API is returning null units, the cached units are immediately available to prevent errors.
+
+### New Functions
+
+Added utility functions for debugging and testing:
+
+- `getUnitCacheStats()` - Returns cache size and all cached units
+- `clearUnitCache(deleteDiskCache)` - Clears the cache (optionally deletes disk file)
+- `loadCacheFromDisk()` - Loads cache from disk (called automatically on startup)
+- `saveCacheToDisk()` - Saves cache to disk (called automatically)
+
+### Testing
+
+Created comprehensive test suite in `test/unit-cache.spec.js` covering:
+
+- Unit caching on first encounter
+- Cache usage when API returns null
+- Cache usage when API returns undefined
+- Handling of N/A units (not cached)
+- Mixed valid and null units in same response
+- Legitimate unit changes (cache updates)
+- Cache clearing
+- Cache statistics
+- **Cache persistence to disk**
+- **Cache loading from disk on restart**
+
+All 10 tests pass, and all existing diagnostic tests (23 tests) continue to pass.
+
+## Benefits
+
+1. **Stability**: Sensors maintain consistent units across polling cycles, even when the API is unstable
+2. **Survives restarts**: Cached units persist across application restarts, protecting against API instability even during initial startup
+3. **No data loss**: Home Assistant statistics remain valid with consistent units
+4. **Transparent**: Works automatically without configuration changes
+5. **Flexible**: Allows legitimate unit changes if the API format evolves
+6. **Observable**: Logs when cached units are used for debugging
+
+## Behavior
+
+### First API Call with Valid Unit
+
+```json
+{
+  "name": "LIFETIME_FUEL_ECONOMY",
+  "value": "10.85",
+  "uom": "KM/L"
+}
+```
+
+→ Unit cached: `LIFETIME_FUEL_ECONOMY` → `KM/L`
+
+→ Sensor created with unit `km/L` (normalized)
+
+### Subsequent API Call with Null Unit
+
+```json
+{
+  "name": "LIFETIME_FUEL_ECONOMY",
+  "value": "10.92",
+  "uom": null
+}
+```
+
+→ Cache lookup finds `KM/L`
+
+→ Log: `Using cached unit for LIFETIME_FUEL_ECONOMY: KM/L (API returned: null)`
+
+→ Sensor maintains unit `km/L` (from cache)
+
+→ **No Home Assistant error!**
+
+## Logging
+
+When the cache is loaded from disk on startup:
+
+```text
+info: Loaded 42 cached units from disk
+```
+
+When the cache is used, you'll see log entries like:
+
+```text
+info: Using cached unit for LIFETIME_FUEL_ECONOMY: KM/L (API returned: null)
+```
+
+When units are cached (debug level):
+
+```text
+debug: Cached unit for LIFETIME_FUEL_ECONOMY: KM/L
+debug: Saved 42 cached units to disk
+```
+
+## Handling First-Run Edge Cases
+
+**Problem solved**: With cache persistence, the "first encounter returns null" problem is mitigated:
+
+1. **After first successful run**: Units are cached to disk
+2. **Application restart during API instability**: Cached units are loaded immediately
+3. **First API call returns null**: Cached unit from disk is used ✅
+4. **No Home Assistant error even on restart!**
+
+The only remaining edge case is the **very first run ever** when:
+
+- No cache file exists yet
+- First API call returns null
+- Sensor created without unit (will correct itself on next poll)
+
+Given the API's instability, this disk persistence is critical for production reliability.
+
+## Limitations
+
+1. **First-run edge case**: On the very first run when no cache exists and the API returns null units, sensors may not have units initially. They will correct themselves on the next successful API call.
+
+2. **Per-name caching**: The cache uses the diagnostic element name as the key. If the same sensor name is used with different units in different contexts (unlikely), there could be conflicts.
+
+## Testing in Production
+
+To verify the fix is working:
+
+1. Monitor logs for "Using cached unit" messages
+2. Check for "Loaded X cached units from disk" on startup
+3. Check Home Assistant for absence of unit conversion errors
+4. Verify sensor statistics remain continuous
+5. Confirm sensors maintain correct units across polling cycles
+6. Verify `.unit_cache_<VIN>.json` file exists and contains data
+
+## Docker Deployment
+
+For Docker users, **a volume mount is required** to persist the cache across container recreations.
+
+### Docker Run
+
+```bash
+docker run -d \
+  --name onstar2mqtt \
+  -v /path/on/host:/app/data \
+  -e UNIT_CACHE_DIR=/app/data \
+  -e ONSTAR_VIN=YOUR_VIN \
+  -e ONSTAR_USERNAME=YOUR_USERNAME \
+  -e ONSTAR_PASSWORD=YOUR_PASSWORD \
+  -e MQTT_HOST=mqtt_broker \
+  your-image:latest
+```
+
+### Docker Compose
+
+```yaml
+version: "3.8"
+
+services:
+  onstar2mqtt:
+    image: your-image:latest
+    container_name: onstar2mqtt
+    environment:
+      - UNIT_CACHE_DIR=/app/data
+      - ONSTAR_VIN=YOUR_VIN
+      - ONSTAR_USERNAME=YOUR_USERNAME
+      - ONSTAR_PASSWORD=YOUR_PASSWORD
+      - MQTT_HOST=mqtt_broker
+    volumes:
+      - ./data:/app/data
+    restart: unless-stopped
+```
+
+### Environment Variable
+
+| Variable         | Description                                                               | Default                                              | Example       |
+| ---------------- | ------------------------------------------------------------------------- | ---------------------------------------------------- | ------------- |
+| `UNIT_CACHE_DIR` | Directory to store cache file                                             | Falls back to `TOKEN_LOCATION`, then `process.cwd()` | `/app/data`   |
+| `TOKEN_LOCATION` | Token storage directory (also used for cache if `UNIT_CACHE_DIR` not set) | `process.cwd()`                                      | `/app/tokens` |
+
+The cache file `.unit_cache_<VIN>.json` will be created in the specified directory, where `<VIN>` is replaced with your vehicle's VIN from the `ONSTAR_VIN` environment variable.
+
+**Note for HA Add-on users:** If you don't set `UNIT_CACHE_DIR`, the cache will automatically be stored in your `TOKEN_LOCATION` directory alongside your authentication tokens, ensuring persistence across container restarts.### Verification
+
+After container starts, check the logs:
+
+```bash
+docker logs onstar2mqtt | grep "Loaded.*cached units"
+```
+
+You should see:
+
+```text
+info: Loaded 42 cached units from disk (/app/data/.unit_cache_<VIN>.json)
+```
+
+Check the cache file exists:
+
+```bash
+docker exec onstar2mqtt ls -la /app/data/.unit_cache_*.json
+```
+
+### Troubleshooting Docker Persistence
+
+**Cache not persisting across container restarts?**
+
+1. Verify volume mount: `docker inspect onstar2mqtt | grep Mounts -A 10`
+2. Check environment variable: `docker exec onstar2mqtt printenv UNIT_CACHE_DIR`
+3. Verify file permissions on host directory
+4. Check logs for "Failed to save unit cache" errors
+
+## User Guide
+
+### What do I need to do?
+
+**Nothing!** The fix works automatically. Your sensors will maintain consistent units even when the API has issues.
+
+### What will I see in logs?
+
+When the cache is loaded on startup:
+
+```text
+info: Loaded 42 cached units from disk
+```
+
+When the cache helps during API instability:
+
+```text
+info: Using cached unit for LIFETIME_FUEL_ECONOMY: KM/L (API returned: null)
+```
+
+This is **normal and expected** - it means the workaround is protecting your sensor data.
+
+### Will this fix lost historical data?
+
+No, this fix prevents **future** unit conversion errors. It cannot restore historical data that was already affected. However:
+
+- Going forward, your sensors will remain stable
+- New statistics will be recorded correctly
+- No more unit conversion warnings
+
+To clean up past errors in Home Assistant:
+
+1. Go to Developer Tools → Statistics
+2. Find affected sensors
+3. Fix unit mismatches using the "Fix issue" button
+
+### Does this affect performance?
+
+No. The cache is lightweight, uses minimal memory, and saves to disk immediately using synchronous writes (similar to how authentication tokens are saved).
+
+## Related Files
+
+- `src/diagnostic.js` - Main implementation
+- `test/unit-cache.spec.js` - Test suite (10 tests)
+- `docs/UNIT_CACHE_FIX.md` - This document

--- a/test/unit-cache.spec.js
+++ b/test/unit-cache.spec.js
@@ -1,0 +1,505 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { Diagnostic, getUnitCacheStats, clearUnitCache } = require('../src/diagnostic');
+
+const VIN = process.env.ONSTAR_VIN || 'default';
+const CACHE_FILE = path.join(process.cwd(), `.unit_cache_${VIN}.json`);
+
+describe('Unit Cache for v3 API Stability', () => {
+    beforeEach(() => {
+        // Clear cache before each test (including disk cache)
+        clearUnitCache(true);
+    });
+
+    afterEach(() => {
+        // Clean up disk cache after tests
+        if (fs.existsSync(CACHE_FILE)) {
+            fs.unlinkSync(CACHE_FILE);
+        }
+    });
+
+    it('should cache valid units on first encounter', () => {
+        const diagResponse = {
+            name: 'FUEL_ECONOMY',
+            diagnosticElements: [
+                {
+                    name: 'LIFETIME_FUEL_ECONOMY',
+                    value: '10.85',
+                    uom: 'KM/L',
+                    cts: '2024-03-13T14:20:15.200+00:00'
+                }
+            ]
+        };
+
+        const diag = new Diagnostic(diagResponse);
+        const stats = getUnitCacheStats();
+
+        assert.ok(stats.size > 0);
+        assert.strictEqual(stats.cachedUnits['LIFETIME_FUEL_ECONOMY'], 'KM/L');
+        assert.strictEqual(diag.diagnosticElements[0].unit, 'km/L'); // Note: unit is normalized
+    });
+
+    it('should use cached unit when API returns null', () => {
+        // First, cache a valid unit
+        const diagResponse1 = {
+            name: 'FUEL_ECONOMY',
+            diagnosticElements: [
+                {
+                    name: 'LIFETIME_FUEL_ECONOMY',
+                    value: '10.85',
+                    uom: 'KM/L',
+                    cts: '2024-03-13T14:20:15.200+00:00'
+                }
+            ]
+        };
+
+        const diag1 = new Diagnostic(diagResponse1);
+        assert.strictEqual(diag1.diagnosticElements[0].unit, 'km/L');
+
+        // Now simulate API returning null unit
+        const diagResponse2 = {
+            name: 'FUEL_ECONOMY',
+            diagnosticElements: [
+                {
+                    name: 'LIFETIME_FUEL_ECONOMY',
+                    value: '10.92',
+                    uom: null,  // API returns null
+                    cts: '2024-03-13T14:25:15.200+00:00'
+                }
+            ]
+        };
+
+        const diag2 = new Diagnostic(diagResponse2);
+        
+        // Should use cached unit instead of null
+        assert.strictEqual(diag2.diagnosticElements[0].unit, 'km/L');
+    });
+
+    it('should use cached unit when API returns undefined', () => {
+        // First, cache a valid unit
+        const diagResponse1 = {
+            name: 'FUEL_ECONOMY',
+            diagnosticElements: [
+                {
+                    name: 'AVERAGE_FUEL_ECONOMY',
+                    value: '9.15',
+                    uom: 'L/100KM',
+                    cts: '2024-03-13T14:20:15.200+00:00'
+                }
+            ]
+        };
+
+        const diag1 = new Diagnostic(diagResponse1);
+        assert.strictEqual(diag1.diagnosticElements[0].unit, 'L/100km');
+
+        // Now simulate API not returning unit field
+        const diagResponse2 = {
+            name: 'FUEL_ECONOMY',
+            diagnosticElements: [
+                {
+                    name: 'AVERAGE_FUEL_ECONOMY',
+                    value: '9.50',
+                    // uom field is missing entirely
+                    cts: '2024-03-13T14:25:15.200+00:00'
+                }
+            ]
+        };
+
+        const diag2 = new Diagnostic(diagResponse2);
+        
+        // Should use cached unit
+        assert.strictEqual(diag2.diagnosticElements[0].unit, 'L/100km');
+    });
+
+    it('should not cache N/A units', () => {
+        const diagResponse = {
+            name: 'BRAKE_FLUID_LOW',
+            diagnosticElements: [
+                {
+                    name: 'BRAKE_FLUID_LOW',
+                    value: 'FALSE',
+                    uom: 'N/A',
+                    cts: '2024-03-13T14:20:15.200+00:00'
+                }
+            ]
+        };
+
+        const diag = new Diagnostic(diagResponse);
+        const stats = getUnitCacheStats();
+
+        // N/A should not be cached
+        assert.strictEqual(stats.cachedUnits['BRAKE_FLUID_LOW'], undefined);
+        assert.strictEqual(diag.diagnosticElements[0].unit, undefined);
+    });
+
+    it('should handle mixed valid and null units in same response', () => {
+        // First, cache units
+        const diagResponse1 = {
+            name: 'FUEL_ECONOMY',
+            diagnosticElements: [
+                {
+                    name: 'AVERAGE_FUEL_ECONOMY',
+                    value: '9.15',
+                    uom: 'L/100KM',
+                    cts: '2024-03-13T14:20:15.200+00:00'
+                },
+                {
+                    name: 'LIFETIME_FUEL_ECONOMY',
+                    value: '10.85',
+                    uom: 'KM/L',
+                    cts: '2024-03-13T14:20:15.200+00:00'
+                }
+            ]
+        };
+
+        const diag1 = new Diagnostic(diagResponse1);
+        assert.strictEqual(diag1.diagnosticElements[0].unit, 'L/100km');
+        assert.strictEqual(diag1.diagnosticElements[1].unit, 'km/L');
+
+        // Now one field has null, one has valid unit
+        const diagResponse2 = {
+            name: 'FUEL_ECONOMY',
+            diagnosticElements: [
+                {
+                    name: 'AVERAGE_FUEL_ECONOMY',
+                    value: '9.50',
+                    uom: null,  // null
+                    cts: '2024-03-13T14:25:15.200+00:00'
+                },
+                {
+                    name: 'LIFETIME_FUEL_ECONOMY',
+                    value: '10.92',
+                    uom: 'KM/L',  // still valid
+                    cts: '2024-03-13T14:25:15.200+00:00'
+                }
+            ]
+        };
+
+        const diag2 = new Diagnostic(diagResponse2);
+        
+        // First uses cache, second uses API value
+        assert.strictEqual(diag2.diagnosticElements[0].unit, 'L/100km');
+        assert.strictEqual(diag2.diagnosticElements[1].unit, 'km/L');
+    });
+
+    it('should handle unit changes (legitimate updates)', () => {
+        // Cache initial unit
+        const diagResponse1 = {
+            name: 'FUEL_ECONOMY',
+            diagnosticElements: [
+                {
+                    name: 'LIFETIME_FUEL_ECONOMY',
+                    value: '10.85',
+                    uom: 'KM/L',
+                    cts: '2024-03-13T14:20:15.200+00:00'
+                }
+            ]
+        };
+
+        const diag1 = new Diagnostic(diagResponse1);
+        assert.strictEqual(diag1.diagnosticElements[0].unit, 'km/L');
+
+        // API legitimately changes unit format
+        const diagResponse2 = {
+            name: 'FUEL_ECONOMY',
+            diagnosticElements: [
+                {
+                    name: 'LIFETIME_FUEL_ECONOMY',
+                    value: '25.5',
+                    uom: 'MPG',  // Changed to different unit
+                    cts: '2024-03-13T14:25:15.200+00:00'
+                }
+            ]
+        };
+
+        const diag2 = new Diagnostic(diagResponse2);
+        
+        // Should accept the new unit and update cache
+        // MPG is not normalized by correctUnitName, so it stays as 'MPG'
+        assert.strictEqual(diag2.diagnosticElements[0].unit, 'MPG');
+        
+        const stats = getUnitCacheStats();
+        // MPG is cached as-is from the API
+        assert.strictEqual(stats.cachedUnits['LIFETIME_FUEL_ECONOMY'], 'MPG');
+    });
+
+    it('should clear cache when requested', () => {
+        const diagResponse = {
+            name: 'FUEL_ECONOMY',
+            diagnosticElements: [
+                {
+                    name: 'LIFETIME_FUEL_ECONOMY',
+                    value: '10.85',
+                    uom: 'KM/L',
+                    cts: '2024-03-13T14:20:15.200+00:00'
+                }
+            ]
+        };
+
+        new Diagnostic(diagResponse);
+        
+        let stats = getUnitCacheStats();
+        assert.ok(stats.size > 0);
+
+        clearUnitCache();
+        
+        stats = getUnitCacheStats();
+        assert.strictEqual(stats.size, 0);
+    });
+
+    it('should provide cache statistics', () => {
+        const diagResponse = {
+            name: 'TEST',
+            diagnosticElements: [
+                {
+                    name: 'SENSOR_A',
+                    value: '100',
+                    uom: 'KM',
+                    cts: '2024-03-13T14:20:15.200+00:00'
+                },
+                {
+                    name: 'SENSOR_B',
+                    value: '50',
+                    uom: 'KPA',
+                    cts: '2024-03-13T14:20:15.200+00:00'
+                }
+            ]
+        };
+
+        new Diagnostic(diagResponse);
+        
+        const stats = getUnitCacheStats();
+        // Note: Cache size may be larger than 2 because converted units are also cached
+        // SENSOR_A (KM) creates SENSOR_A and SENSOR_A MI cache entries
+        // SENSOR_B (KPA) creates SENSOR_B and SENSOR_B PSI cache entries
+        assert.ok(stats.size >= 2);
+        assert.ok('SENSOR_A' in stats.cachedUnits);
+        assert.ok('SENSOR_B' in stats.cachedUnits);
+        assert.strictEqual(stats.cachedUnits['SENSOR_A'], 'KM');
+        assert.strictEqual(stats.cachedUnits['SENSOR_B'], 'KPA');
+    });
+
+    it('should persist cache to disk immediately', () => {
+        const diagResponse = {
+            name: 'FUEL_ECONOMY',
+            diagnosticElements: [
+                {
+                    name: 'LIFETIME_FUEL_ECONOMY',
+                    value: '10.85',
+                    uom: 'KM/L',
+                    cts: '2024-03-13T14:20:15.200+00:00'
+                }
+            ]
+        };
+
+        new Diagnostic(diagResponse);
+        
+        assert.ok(fs.existsSync(CACHE_FILE), 'Cache file should exist');
+        
+        const data = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf8'));
+        assert.strictEqual(data['LIFETIME_FUEL_ECONOMY'], 'KM/L');
+    });
+
+    it('should load cache from disk on module reload', () => {
+        // First, create and persist cache
+        const diagResponse1 = {
+            name: 'FUEL_ECONOMY',
+            diagnosticElements: [
+                {
+                    name: 'TEST_SENSOR',
+                    value: '100',
+                    uom: 'KM',
+                    cts: '2024-03-13T14:20:15.200+00:00'
+                }
+            ]
+        };
+
+        new Diagnostic(diagResponse1);
+
+        // Verify file exists
+        assert.ok(fs.existsSync(CACHE_FILE));
+
+        // Clear in-memory cache only (not disk)
+        clearUnitCache(false);
+        
+        // Verify in-memory cache is empty
+        let stats = getUnitCacheStats();
+        assert.strictEqual(stats.size, 0);
+
+        // Reload module to trigger loadCacheFromDisk
+        delete require.cache[require.resolve('../src/diagnostic')];
+        const { getUnitCacheStats: reloadedStats } = require('../src/diagnostic');
+
+        const newStats = reloadedStats();
+        assert.ok(newStats.size > 0, 'Cache should be loaded from disk');
+        assert.strictEqual(newStats.cachedUnits['TEST_SENSOR'], 'KM');
+    });
+
+    // Error handling tests
+    it('should handle disk cache deletion errors gracefully', () => {
+        const diagResponse = {
+            name: 'TEST',
+            diagnosticElements: [
+                {
+                    name: 'TEST_SENSOR',
+                    value: '100',
+                    uom: 'KM',
+                    cts: '2024-03-13T14:20:15.200+00:00'
+                }
+            ]
+        };
+
+        new Diagnostic(diagResponse);
+        
+        // Create cache file that's already deleted
+        clearUnitCache(true);
+        
+        // Try to delete non-existent file (should not throw)
+        assert.doesNotThrow(() => {
+            clearUnitCache(true);
+        });
+    });
+
+    it('should handle corrupted cache file on load', () => {
+        // Write corrupted JSON to cache file
+        fs.writeFileSync(CACHE_FILE, '{corrupted json', 'utf8');
+        
+        // Reload module - should handle gracefully
+        assert.doesNotThrow(() => {
+            delete require.cache[require.resolve('../src/diagnostic')];
+            require('../src/diagnostic');
+        });
+        
+        // Clean up
+        if (fs.existsSync(CACHE_FILE)) {
+            fs.unlinkSync(CACHE_FILE);
+        }
+    });
+
+    it('should handle directory creation for custom cache paths', () => {
+        // This is implicitly tested by the disk persistence tests
+        // but we verify the directory exists after those tests run
+        const cacheDir = process.env.UNIT_CACHE_DIR || process.cwd();
+        assert.ok(fs.existsSync(cacheDir), 'Cache directory should exist');
+    });
+
+    it('should create cache directory if it does not exist', function() {
+        // Set a custom cache directory that doesn't exist
+        const testDir = path.join(process.cwd(), 'test-cache-dir-' + Date.now());
+        process.env.UNIT_CACHE_DIR = testDir;
+        
+        // Ensure it doesn't exist
+        if (fs.existsSync(testDir)) {
+            fs.rmSync(testDir, { recursive: true });
+        }
+        
+        // Reload module to trigger directory creation
+        delete require.cache[require.resolve('../src/diagnostic')];
+        const { Diagnostic } = require('../src/diagnostic');
+        
+        // Create a diagnostic to trigger cache operation
+        const diagResponse = {
+            name: 'TEST',
+            diagnosticElements: [
+                {
+                    name: 'TEST_SENSOR',
+                    value: '100',
+                    uom: 'KM',
+                    cts: '2024-03-13T14:20:15.200+00:00'
+                }
+            ]
+        };
+        
+        new Diagnostic(diagResponse);
+        
+        // Verify directory was created
+        assert.ok(fs.existsSync(testDir), 'Custom cache directory should be created');
+        
+        // Cleanup
+        delete process.env.UNIT_CACHE_DIR;
+        if (fs.existsSync(testDir)) {
+            fs.rmSync(testDir, { recursive: true });
+        }
+        
+        // Reload module back to normal state
+        delete require.cache[require.resolve('../src/diagnostic')];
+        require('../src/diagnostic');
+    });
+
+    it('should use VIN-specific cache file names', function() {
+        // Set a test VIN
+        const testVIN = 'TEST123VIN456';
+        process.env.ONSTAR_VIN = testVIN;
+        
+        // Reload module with new VIN
+        delete require.cache[require.resolve('../src/diagnostic')];
+        const { Diagnostic, clearUnitCache } = require('../src/diagnostic');
+        
+        const diagResponse = {
+            name: 'TEST',
+            diagnosticElements: [
+                {
+                    name: 'TEST_SENSOR',
+                    value: '100',
+                    uom: 'KM',
+                    cts: '2024-03-13T14:20:15.200+00:00'
+                }
+            ]
+        };
+        
+        new Diagnostic(diagResponse);
+        
+        const vinCacheFile = path.join(process.cwd(), `.unit_cache_${testVIN}.json`);
+        assert.ok(fs.existsSync(vinCacheFile), 'VIN-specific cache file should exist');
+        
+        // Cleanup
+        clearUnitCache(true);
+        delete process.env.ONSTAR_VIN;
+        
+        // Reload module back to normal state
+        delete require.cache[require.resolve('../src/diagnostic')];
+        require('../src/diagnostic');
+    });
+
+    it('should fall back to TOKEN_LOCATION if UNIT_CACHE_DIR not set', function() {
+        // Set TOKEN_LOCATION but not UNIT_CACHE_DIR
+        const testTokenDir = path.join(process.cwd(), 'test-token-dir-' + Date.now());
+        fs.mkdirSync(testTokenDir, { recursive: true });
+        process.env.TOKEN_LOCATION = testTokenDir;
+        delete process.env.UNIT_CACHE_DIR;
+        
+        // Reload module to pick up TOKEN_LOCATION
+        delete require.cache[require.resolve('../src/diagnostic')];
+        const { Diagnostic, clearUnitCache } = require('../src/diagnostic');
+        
+        const diagResponse = {
+            name: 'TEST',
+            diagnosticElements: [
+                {
+                    name: 'TEST_SENSOR',
+                    value: '100',
+                    uom: 'KM',
+                    cts: '2024-03-13T14:20:15.200+00:00'
+                }
+            ]
+        };
+        
+        new Diagnostic(diagResponse);
+        
+        const VIN = process.env.ONSTAR_VIN || 'default';
+        const cacheFile = path.join(testTokenDir, `.unit_cache_${VIN}.json`);
+        assert.ok(fs.existsSync(cacheFile), 'Cache file should exist in TOKEN_LOCATION');
+        
+        // Cleanup
+        clearUnitCache(true);
+        delete process.env.TOKEN_LOCATION;
+        if (fs.existsSync(testTokenDir)) {
+            fs.rmSync(testTokenDir, { recursive: true });
+        }
+        
+        // Reload module back to normal state
+        delete require.cache[require.resolve('../src/diagnostic')];
+        require('../src/diagnostic');
+    });
+});


### PR DESCRIPTION
- Implement in-memory and disk-persistent unit cache to handle OnStar v3 API instability
- Cache units when valid, use cached units when API returns null/undefined
- VIN-specific cache files (.unit_cache_<VIN>.json) to support multi-vehicle deployments
- Environment variable support: UNIT_CACHE_DIR (primary), TOKEN_LOCATION (fallback)
- Immediate synchronous disk persistence (no debounce) similar to token handling
- Auto-load cache on startup to survive restarts during API instability
- Add 16 comprehensive tests with full coverage of caching, persistence, and error handling
- Exclude 'N/A' pseudo-units from caching
- Add utility functions: getUnitCacheStats(), clearUnitCache()
- Update documentation with Docker deployment examples and troubleshooting
- Console logging includes cache file paths for easier debugging

Fixes: Home Assistant unit conversion errors when OnStar API intermittently returns null units