### PR TITLE
fix: Add Workflow to Sync patchright Version on onstarjs2 Updates

### DIFF
--- a/.github/workflows/sync-patchright.yml
+++ b/.github/workflows/sync-patchright.yml
@@ -1,0 +1,120 @@
+name: Sync Patchright Version
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'package.json'
+  workflow_dispatch:
+
+jobs:
+  sync-patchright-pr:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && (github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]')
+    
+    steps:
+      - name: Check if onstarjs2 changed
+        id: check-onstarjs2
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            
+            const packageJsonFile = files.find(f => f.filename === 'package.json');
+            if (!packageJsonFile || !packageJsonFile.patch) {
+              console.log('No package.json changes found');
+              return false;
+            }
+            
+            const hasOnstarjs2Change = packageJsonFile.patch.includes('onstarjs2');
+            console.log('onstarjs2 changed:', hasOnstarjs2Change);
+            return hasOnstarjs2Change;
+
+      - name: Checkout code
+        if: steps.check-onstarjs2.outputs.result == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.PAT_TOKEN }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        if: steps.check-onstarjs2.outputs.result == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run sync-patchright
+        if: steps.check-onstarjs2.outputs.result == 'true'
+        run: npm run sync-patchright
+
+      - name: Update package-lock.json
+        if: steps.check-onstarjs2.outputs.result == 'true'
+        run: npm install --package-lock-only --legacy-peer-deps
+
+      - name: Check for changes
+        if: steps.check-onstarjs2.outputs.result == 'true'
+        id: git-check
+        run: |
+          git diff --exit-code package.json package-lock.json || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: Commit and push changes
+        if: steps.check-onstarjs2.outputs.result == 'true' && steps.git-check.outputs.changed == 'true'
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add package.json package-lock.json
+          git commit -m "chore: sync patchright version with onstarjs2"
+          git push
+
+  sync-patchright-manual:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.PAT_TOKEN }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run sync-patchright
+        run: npm run sync-patchright
+
+      - name: Update package-lock.json
+        run: npm install --package-lock-only --legacy-peer-deps
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --exit-code package.json package-lock.json || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: Create PR with changes
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          BRANCH_NAME="chore/sync-patchright-$(date +%Y%m%d-%H%M%S)"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git checkout -b "$BRANCH_NAME"
+          git add package.json package-lock.json
+          git commit -m "chore: sync patchright version with onstarjs2"
+          git push -u origin "$BRANCH_NAME"
+          gh pr create --title "chore: sync patchright version with onstarjs2" \
+            --body "This PR was automatically created by the manual sync-patchright workflow to update the patchright override to match the version expected by onstarjs2." \
+            --base main
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+
+      - name: No changes needed
+        if: steps.git-check.outputs.changed != 'true'
+        run: echo "Patchright is already in sync with onstarjs2. No changes needed."


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the synchronization of the `patchright` version in `package.json` with the version expected by `onstarjs2`. The workflow runs automatically for dependency bot pull requests and can also be triggered manually. It ensures that both `package.json` and `package-lock.json` are updated and commits or creates a PR with the changes if necessary.

Automation for dependency updates:

* Added `.github/workflows/sync-patchright.yml` to automatically sync the `patchright` version in `package.json` when dependency bots (`dependabot[bot]` or `renovate[bot]`) open or update a pull request that modifies `onstarjs2`. The workflow checks for changes, runs the sync script, updates lock files, and commits changes if needed.

Manual workflow support:

* Added a manual trigger (`workflow_dispatch`) to allow maintainers to run the sync process directly from GitHub Actions. If changes are detected, the workflow creates a new branch and pull request with the updates.