### PR TITLE
Fix: Resolve topicArray.map crash from lodash removal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1007,9 +1007,9 @@ logger.info('!-- Starting OnStar2MQTT Polling --!');
         const run = async () => {
             let topicArray;
             if (!mqttConfig.pollingStatusTopic) {
-                topicArray = [mqttHA.getPollingStatusTopic(), '/', 'state'].join('');
+                topicArray = [mqttHA.getPollingStatusTopic(), '/', 'state'];
             } else {
-                topicArray = [mqttConfig.pollingStatusTopic, '/', 'state'].join('');
+                topicArray = [mqttConfig.pollingStatusTopic, '/', 'state'];
             }
             const pollingStatusTopicState = topicArray.map(item => item.topic || item).join('');
             logger.info(`pollingStatusTopicState: ${pollingStatusTopicState}`);
@@ -1042,9 +1042,9 @@ logger.info('!-- Starting OnStar2MQTT Polling --!');
 
             let topicArrayTF;
             if (!mqttConfig.pollingStatusTopic) {
-                topicArrayTF = [mqttHA.getPollingStatusTopic(), '/', 'lastpollsuccessful'].join('');
+                topicArrayTF = [mqttHA.getPollingStatusTopic(), '/', 'lastpollsuccessful'];
             } else {
-                topicArrayTF = [mqttConfig.pollingStatusTopic, '/', 'lastpollsuccessful'].join('');
+                topicArrayTF = [mqttConfig.pollingStatusTopic, '/', 'lastpollsuccessful'];
             }
             const pollingStatusTopicTF = topicArrayTF.map(item => item.topic || item).join('');
             logger.info(`pollingStatusTopicTF, ${pollingStatusTopicTF}`);
@@ -1367,18 +1367,18 @@ logger.info('!-- Starting OnStar2MQTT Polling --!');
                 
                 let topicArray;
                 if (!mqttConfig.pollingStatusTopic) {
-                    topicArray = [mqttHA.getPollingStatusTopic(), '/', 'state'].join('');
+                    topicArray = [mqttHA.getPollingStatusTopic(), '/', 'state'];
                 } else {
-                    topicArray = [mqttConfig.pollingStatusTopic, '/', 'state'].join('');
+                    topicArray = [mqttConfig.pollingStatusTopic, '/', 'state'];
                 }
                 const pollingStatusTopicState = topicArray.map(item => item.topic || item).join('');
                 logger.debug('pollingStatusTopicState', { pollingStatusTopicState });
 
                 let topicArrayTF;
                 if (!mqttConfig.pollingStatusTopic) {
-                    topicArrayTF = [mqttHA.getPollingStatusTopic(), '/', 'lastpollsuccessful'].join('');
+                    topicArrayTF = [mqttHA.getPollingStatusTopic(), '/', 'lastpollsuccessful'];
                 } else {
-                    topicArrayTF = [mqttConfig.pollingStatusTopic, '/', 'lastpollsuccessful'].join('');
+                    topicArrayTF = [mqttConfig.pollingStatusTopic, '/', 'lastpollsuccessful'];
                 }
                 const pollingStatusTopicTF = topicArrayTF.map(item => item.topic || item).join('');
                 logger.debug('pollingStatusTopicTF', { pollingStatusTopicTF });


### PR DESCRIPTION
During lodash removal, _.concat() was incorrectly replaced with [...].join('') which created strings instead of arrays. This caused 'topicArray.map is not a function' crashes when the polling loop attempted to map over the topic arrays.

Fixed by removing premature .join('') calls, ensuring topicArray and topicArrayTF remain as arrays before being passed to .map() operations.

Changes:
- Lines 1010, 1012: Fixed topicArray in run() function
- Lines 1045, 1047: Fixed topicArrayTF in run() function
- Lines 1370, 1372: Fixed topicArray in error handler
- Lines 1379, 1381: Fixed topicArrayTF in error handler