### PR TITLE
fix: update HA sensors when refreshEVChargingMetrics command is used

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -901,8 +901,8 @@ const configureMQTT = async (commands, client, mqttHA) => {
                             logger.info(`Recall sensor updated: ${recallState.recall_count} total recalls, ${recallState.active_recalls_count} active`);
                         }
                         
-                        // Handle getEVChargingMetrics command - create EV charging sensors
-                        if (command === 'getEVChargingMetrics') {
+                        // Handle getEVChargingMetrics and refreshEVChargingMetrics commands - create EV charging sensors
+                        if (command === 'getEVChargingMetrics' || command === 'refreshEVChargingMetrics') {
                             const evMetricsConfigs = mqttHA.getEVChargingMetricsConfigs(data.response);
                             
                             logger.info(`Publishing ${evMetricsConfigs.length} EV charging metric sensors...`);


### PR DESCRIPTION
## Summary

The `refreshEVChargingMetrics` command returns the same data format as `getEVChargingMetrics` but was not triggering the MQTT sensor updates. This caused Home Assistant entities to not update until the next general poll even though the logs showed the updated metrics.

## Changes

- Added `refreshEVChargingMetrics` to the condition that triggers EV charging sensor updates in `index.js`

## Testing

- All existing tests pass
- Verified both commands return identical response structures
- The `getEVChargingMetricsConfigs()` function already handles both response formats correctly

## Related

- Reported in BigThunderSR/homeassistant-addons-onstar2mqtt#1584