### PR TITLE
chore: add devcontainer for isolated development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "OnStar2MQTT",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "npm install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.vscode-typescript-next",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  },
+  "mounts": []
+}


### PR DESCRIPTION
Add devcontainer.json for secure, isolated development:  - Node 22 base image - Docker-in-Docker for standalone/container builds - GitHub CLI - No host filesystem mounts (security isolation)