### PR TITLE
fix: pin devcontainer to bookworm for OnStarJS compatibility

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "OnStar2MQTT",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22-bookworm",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}


### PR DESCRIPTION
The javascript-node:22 base image moved to Debian Trixie, which is incompatible with OnStarJS/patchright. This pins the devcontainer to bookworm.