### PR TITLE
fix: add sensor handlers for EE_BPLM, BRAKE_PAD_LIFE, and OTHER diagnostics (2025 Equinox)

### DIFF
--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -2084,6 +2084,14 @@ class MQTT {
             case 'CHARGE_ABORT_REASON_PID':
             case 'CHARGE ABORT REASON PID':
                 return this.mapSensorConfigPayload(diag, diagEl, undefined, undefined, undefined, undefined, 'mdi:alert-circle');
+            case 'EE_BPLM':
+            case 'EE BPLM':
+                return this.mapSensorConfigPayload(diag, diagEl, undefined, undefined, undefined, undefined, 'mdi:car-brake-worn-linings');
+            case 'BRAKE_PAD_LIFE':
+            case 'BRAKE PAD LIFE':
+                return this.mapSensorConfigPayload(diag, diagEl, undefined, undefined, undefined, undefined, 'mdi:car-brake-worn-linings');
+            case 'OTHER':
+                return this.mapSensorConfigPayload(diag, diagEl, undefined, undefined, undefined, undefined, 'mdi:help-circle-outline');
             default:
                 return this.mapSensorConfigPayload(diag, diagEl, 'measurement');
         }

--- a/test/diagnostic-sample-v3-ev-1.json
+++ b/test/diagnostic-sample-v3-ev-1.json
@@ -431,6 +431,49 @@
               "cts": "2025-10-11T03:19:03.350+00:00"
             }
           ]
+        },
+        {
+          "name": "EE_BPLM",
+          "displayName": "Brake Pad Life Monitor",
+          "description": "Brake Pad Life Monitor",
+          "status": "GOOD",
+          "statusColor": "GREEN",
+          "value": null,
+          "uom": null,
+          "cts": "2025-10-11T02:50:31.200+00:00",
+          "recommendedAction": null,
+          "diagnosticElements": [
+            {
+              "name": "EE_BPLM",
+              "displayName": "Brake Pad Life Monitor",
+              "description": "Brake Pad Life Monitor",
+              "status": "GOOD",
+              "statusColor": "GREEN",
+              "value": "GOOD",
+              "uom": "N/A",
+              "cts": "2025-10-11T02:50:31.200+00:00"
+            },
+            {
+              "name": "BRAKE_PAD_LIFE",
+              "displayName": "Brake Pad Life",
+              "description": "Brake Pad Life",
+              "status": "GOOD",
+              "statusColor": "GREEN",
+              "value": "GOOD",
+              "uom": "N/A",
+              "cts": "2025-10-11T02:50:31.200+00:00"
+            },
+            {
+              "name": "OTHER",
+              "displayName": "Other",
+              "description": "Other",
+              "status": "GOOD",
+              "statusColor": "GREEN",
+              "value": "NO_ACTION_REQUIRED",
+              "uom": "N/A",
+              "cts": "2025-10-11T02:50:31.200+00:00"
+            }
+          ]
         }
       ],
       "advDiagnostics": {

--- a/test/mqtt.spec.js
+++ b/test/mqtt.spec.js
@@ -3214,6 +3214,36 @@ describe('MQTT', () => {
             assert.strictEqual(config.icon, 'mdi:wiper-wash');
         });
 
+        it('should map EE_BPLM correctly', () => {
+            const diagResponse = {
+                name: 'EE_BPLM',
+                diagnosticElements: [{ name: 'EE_BPLM', value: 'GOOD', uom: 'N/A' }]
+            };
+            const d = new Diagnostic(diagResponse);
+            const config = mqtt.getConfigPayload(d, d.diagnosticElements[0]);
+            assert.strictEqual(config.icon, 'mdi:car-brake-worn-linings');
+        });
+
+        it('should map BRAKE_PAD_LIFE correctly', () => {
+            const diagResponse = {
+                name: 'EE_BPLM',
+                diagnosticElements: [{ name: 'BRAKE_PAD_LIFE', value: 'GOOD', uom: 'N/A' }]
+            };
+            const d = new Diagnostic(diagResponse);
+            const config = mqtt.getConfigPayload(d, d.diagnosticElements[0]);
+            assert.strictEqual(config.icon, 'mdi:car-brake-worn-linings');
+        });
+
+        it('should map OTHER correctly', () => {
+            const diagResponse = {
+                name: 'EE_BPLM',
+                diagnosticElements: [{ name: 'OTHER', value: 'NO_ACTION_REQUIRED', uom: 'N/A' }]
+            };
+            const d = new Diagnostic(diagResponse);
+            const config = mqtt.getConfigPayload(d, d.diagnosticElements[0]);
+            assert.strictEqual(config.icon, 'mdi:help-circle-outline');
+        });
+
         it('should map BATTERY_STATE_OF_CHARGE_CRITICALLY_LOW correctly', () => {
             const diagResponse = {
                 name: 'BATTERY_STATE_OF_CHARGE_CRITICALLY_LOW',


### PR DESCRIPTION
## Problem

The 2025 Chevrolet Equinox reports a **Brake Pad Life Monitor** diagnostic group (`EE_BPLM`) containing three elements that have no explicit handlers in `getConfigMapping`:

| Element name | API value example |
|---|---|
| `EE_BPLM` | `"GOOD"` |
| `BRAKE_PAD_LIFE` | `"GOOD"` |
| `OTHER` | `"NO_ACTION_REQUIRED"` |

All three fall through to the `default` catch-all at the bottom of the switch, which applies `state_class: "measurement"` to every unrecognized element. Because HA requires numeric values for `measurement`-class sensors, it logs errors whenever these string-valued sensors are updated.

The `value_json.other` warning visible in HA logs is produced by the auto-generated template for the `OTHER` element hitting this same path.

## Fix

Three `case` blocks added in `src/mqtt.js` `getConfigMapping` immediately before `default` (now at line 2095):

```js
case 'EE_BPLM':
case 'EE BPLM':
    return this.mapSensorConfigPayload(diag, diagEl, undefined, undefined, undefined, undefined, 'mdi:car-brake-worn-linings');
case 'BRAKE_PAD_LIFE':
case 'BRAKE PAD LIFE':
    return this.mapSensorConfigPayload(diag, diagEl, undefined, undefined, undefined, undefined, 'mdi:car-brake-worn-linings');
case 'OTHER':
    return this.mapSensorConfigPayload(diag, diagEl, undefined, undefined, undefined, undefined, 'mdi:help-circle-outline');
```

Passing `undefined` for `state_class` prevents HA from applying numeric-only validation to these string-valued sensors. Icons follow the existing conventions used by similar diagnostic sensors.

Space-variant names (`EE BPLM`, `BRAKE PAD LIFE`) are included to match the API v1 naming pattern used throughout the rest of the switch.

## Tests

- Fixture entry added to `test/diagnostic-sample-v3-ev-1.json` with all three elements and realistic values from a reported 2025 Equinox diagnostic payload.
- Three `it()` blocks added to `test/mqtt.spec.js` verifying icon assignment for each element.
- All **460 tests pass**.

## Notes

These diagnostic element names and values were identified from diagnostic data reported by a 2025 Chevrolet Equinox user. 