### PR TITLE
fix: correct state_class for lifetime accumulator and trip sensors

### DIFF
--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -1184,7 +1184,7 @@ class MQTT {
                     unique_id: `${this.vehicle.vin}_ev_trip_odometer`,
                     state_topic: `${this.prefix}/sensor/${this.instance}/ev_trip_odometer/state`,
                     device_class: "distance",
-                    state_class: "total_increasing",
+                    state_class: "measurement",
                     unit_of_measurement: "km",
                     icon: "mdi:map-marker-distance",
                     device: this.getDevicePayload(),
@@ -1349,7 +1349,7 @@ class MQTT {
                     unique_id: `${this.vehicle.vin}_ev_charging_lifetime_energy`,
                     state_topic: `${this.prefix}/sensor/${this.instance}/ev_charging_lifetime_energy/state`,
                     device_class: "energy",
-                    state_class: "total_increasing",
+                    state_class: "total",
                     unit_of_measurement: "kWh",
                     icon: "mdi:lightning-bolt",
                     device: this.getDevicePayload(),
@@ -1422,7 +1422,7 @@ class MQTT {
                     unique_id: `${this.vehicle.vin}_ev_charging_odometer`,
                     state_topic: `${this.prefix}/sensor/${this.instance}/ev_charging_odometer/state`,
                     device_class: "distance",
-                    state_class: "total_increasing",
+                    state_class: "total",
                     unit_of_measurement: "km",
                     icon: "mdi:counter",
                     device: this.getDevicePayload(),
@@ -1797,7 +1797,7 @@ class MQTT {
             // API v1 uses spaces, API v3 uses underscores - support both
             case 'LIFETIME ENERGY USED':
             case 'LIFETIME_ENERGY_USED':
-                return this.mapSensorConfigPayload(diag, diagEl, 'total_increasing', 'energy', undefined, undefined, 'mdi:lightning-bolt');
+                return this.mapSensorConfigPayload(diag, diagEl, 'total', 'energy', undefined, undefined, 'mdi:lightning-bolt');
             case 'INTERM VOLT BATT VOLT':
                 return this.mapSensorConfigPayload(diag, diagEl, 'measurement', 'voltage', undefined, undefined, 'mdi:car-battery');
             case 'EV PLUG VOLTAGE':
@@ -1934,14 +1934,14 @@ class MQTT {
                 return this.mapSensorConfigPayload(diag, diagEl, 'measurement', 'distance', undefined, undefined, 'mdi:map-marker-path');
             case 'ODOMETER':
             case 'ODOMETER MI':
-                return this.mapSensorConfigPayload(diag, diagEl, 'total_increasing', 'distance', undefined, undefined, 'mdi:counter');
+                return this.mapSensorConfigPayload(diag, diagEl, 'total', 'distance', undefined, undefined, 'mdi:counter');
             case 'LIFETIME FUEL USED':
             case 'LIFETIME FUEL USED GAL':
             case 'LIFETIME FUEL USED L':
             case 'LIFETIME_FUEL_USED':
             case 'LIFETIME_FUEL_USED_GAL':
             case 'LIFETIME_FUEL_USED_L':
-                return this.mapSensorConfigPayload(diag, diagEl, 'total_increasing', 'volume', undefined, undefined, 'mdi:gas-station');
+                return this.mapSensorConfigPayload(diag, diagEl, 'total', 'volume', undefined, undefined, 'mdi:gas-station');
             case 'FUEL AMOUNT':
             case 'FUEL AMOUNT GAL':
                 return this.mapSensorConfigPayload(diag, diagEl, 'measurement', 'volume_storage', undefined, undefined, 'mdi:gas-station');
@@ -2021,7 +2021,7 @@ class MQTT {
             case 'ODO_READ':
             case 'ODO_READ MI':
             case 'ODO_READ_MI':
-                return this.mapSensorConfigPayload(diag, diagEl, 'total_increasing', 'distance', undefined, undefined, 'mdi:counter');
+                return this.mapSensorConfigPayload(diag, diagEl, 'total', 'distance', undefined, undefined, 'mdi:counter');
             case 'TRIP A ODO':
             case 'TRIP A ODO MI':
             case 'TRIP_A_ODO':

--- a/test/ev-charging-metrics.spec.js
+++ b/test/ev-charging-metrics.spec.js
@@ -154,7 +154,7 @@ describe('EV Charging Metrics', () => {
             assert.strictEqual(lifetimeEnergySensor.payload.name, 'EV Charging Lifetime Energy');
             assert.strictEqual(lifetimeEnergySensor.payload.device_class, 'energy');
             assert.strictEqual(lifetimeEnergySensor.payload.unit_of_measurement, 'kWh');
-            assert.strictEqual(lifetimeEnergySensor.payload.state_class, 'total_increasing');
+            assert.strictEqual(lifetimeEnergySensor.payload.state_class, 'total');
             assert.strictEqual(lifetimeEnergySensor.state, 14213.1);
 
             // Check EV Charging Range sensor
@@ -183,7 +183,7 @@ describe('EV Charging Metrics', () => {
             assert.strictEqual(odometerSensor.payload.name, 'EV Charging Odometer');
             assert.strictEqual(odometerSensor.payload.device_class, 'distance');
             assert.strictEqual(odometerSensor.payload.unit_of_measurement, 'km');
-            assert.strictEqual(odometerSensor.payload.state_class, 'total_increasing');
+            assert.strictEqual(odometerSensor.payload.state_class, 'total');
             assert.strictEqual(odometerSensor.state, 58062.09);
 
             // Check EV Charging Temperature sensor
@@ -379,12 +379,12 @@ describe('EV Charging Metrics', () => {
             const temperatureSensor = configs.find(c => c.topic.includes('ev_charging_temperature'));
             
             assert.strictEqual(tclSensor.payload.state_class, 'measurement');
-            assert.strictEqual(tripOdoSensor.payload.state_class, 'total_increasing');
+            assert.strictEqual(tripOdoSensor.payload.state_class, 'measurement');
             assert.strictEqual(lifeConsSensor.payload.state_class, 'measurement');
             assert.strictEqual(batteryLevelSensor.payload.state_class, 'measurement');
-            assert.strictEqual(lifetimeEnergySensor.payload.state_class, 'total_increasing');
+            assert.strictEqual(lifetimeEnergySensor.payload.state_class, 'total');
             assert.strictEqual(rangeSensor.payload.state_class, 'measurement');
-            assert.strictEqual(odometerSensor.payload.state_class, 'total_increasing');
+            assert.strictEqual(odometerSensor.payload.state_class, 'total');
             assert.strictEqual(temperatureSensor.payload.state_class, 'measurement');
         });
     });

--- a/test/mqtt.spec.js
+++ b/test/mqtt.spec.js
@@ -189,7 +189,7 @@ describe('MQTT', () => {
                         name: '2020 foo bar',
                         suggested_area: "2020 foo bar Sensors",
                     },
-                    state_class: 'total_increasing',
+                    state_class: 'total',
                     device_class: 'distance',
                     icon: 'mdi:counter',
                     json_attributes_template: "{{ {'last_updated': value_json.odometer_last_updated, 'status': value_json.odometer_status, 'status_color': value_json.odometer_status_color} | tojson }}",
@@ -213,7 +213,7 @@ describe('MQTT', () => {
                         name: '2020 foo bar',
                         suggested_area: "2020 foo bar Sensors",
                     },
-                    state_class: 'total_increasing',
+                    state_class: 'total',
                     device_class: 'distance',
                     icon: 'mdi:counter',
                     json_attributes_template: "{{ {'last_updated': value_json.odometer_mi_last_updated, 'status': value_json.odometer_mi_status, 'status_color': value_json.odometer_mi_status_color} | tojson }}",
@@ -616,7 +616,7 @@ describe('MQTT', () => {
                         name: '2020 foo bar',
                         suggested_area: "2020 foo bar Sensors",
                     },
-                    state_class: 'total_increasing',
+                    state_class: 'total',
                     device_class: 'volume',
                     icon: 'mdi:gas-station',
                     json_attributes_template: "{{ {'last_updated': value_json.lifetime_fuel_used_last_updated, 'status': value_json.lifetime_fuel_used_status, 'status_color': value_json.lifetime_fuel_used_status_color} | tojson }}",
@@ -2214,7 +2214,7 @@ describe('MQTT', () => {
             };
             const result = mqtt.getConfigMapping(d, diagEl);
             assert.strictEqual(result.device_class, 'energy');
-            assert.strictEqual(result.state_class, 'total_increasing');
+            assert.strictEqual(result.state_class, 'total');
         });
 
         it('should map sensor config payload for battery temperature', () => {
@@ -3096,7 +3096,7 @@ describe('MQTT', () => {
             const d = new Diagnostic(diagResponse);
             const config = mqtt.getConfigPayload(d, d.diagnosticElements[0]);
             assert.strictEqual(config.icon, 'mdi:counter');
-            assert.strictEqual(config.state_class, 'total_increasing');
+            assert.strictEqual(config.state_class, 'total');
             assert.strictEqual(config.device_class, 'distance');
         });
 


### PR DESCRIPTION
## Summary

Corrects `state_class` for sensors that were incorrectly using `total_increasing`, causing false HA warnings.

## Problem

The odometer sensor (`ODO_READ`) and other lifetime accumulators are published with `state_class: total_increasing`, but these values never reset to zero. The OnStar API returns unrounded floats with noise in trailing digits (e.g. `16290.0322305237` → `16290.0322274169`), and HA's strict `total_increasing` enforcement interprets the ~0.000003 jitter as a "decrease," logging recurring warnings:

```
Entity sensor.<vehicle>_odo_read has state class total_increasing, but its
state is not strictly increasing.
```

## Fix

**Changed to `total`** (lifetime accumulators that never reset):
- `ODOMETER` / `ODOMETER MI`
- `ODO_READ` / `ODO_READ MI` / `ODO_READ_MI`
- `ev_charging_odometer`
- `ev_charging_lifetime_energy`
- `LIFETIME ENERGY USED` / `LIFETIME_ENERGY_USED`
- `LIFETIME FUEL USED` (all variants)

**Changed to `measurement`** (user-resettable trip counter, consistent with `TRIP A ODO`):
- `ev_trip_odometer`

## Tests Updated

- `test/mqtt.spec.js`: Updated assertions for `ODOMETER`, `ODOMETER MI`, `LIFETIME FUEL USED`, `LIFETIME ENERGY USED`, and `ODO READ MI` sensors
- `test/ev-charging-metrics.spec.js`: Updated assertions for `ev_charging_lifetime_energy`, `ev_charging_odometer`, and `ev_trip_odometer` sensors
- All 591 tests passing

## Why these are the correct state classes

- **`total`**: For running totals that never reset. An odometer, lifetime fuel used, and lifetime energy used are monotonic and never go back to zero.
- **`measurement`**: For point-in-time readings. A trip odometer is user-resettable and reports the current trip distance — same semantics as `TRIP A ODO` which already uses `measurement`.
- **`total_increasing`**: For counters that periodically reset to zero (e.g. daily energy). None of the changed sensors exhibit this behavior.

Fixes BigThunderSR/homeassistant-addons-onstar2mqtt#1807